### PR TITLE
Add badges to README

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include *.txt
 include *.rst
-recursive-include docs *.txt
 recursive-include sentrylogs/conf *.py
 prune sentrylogs/env

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,32 @@
-===========
-Sentry Logs
-===========
+============================
+Sentry Logs |latest-version|
+============================
+
+|build-status| |health| |python-support| |downloads| |license|
 
 Sentry Logs allows you to send Logs to Sentry, only Nginx error log is
 currently supported, but extending the library to support more log files
 is planned.
+
+
+.. |latest-version| image:: https://img.shields.io/pypi/v/sentrylogs.svg
+   :alt: Latest version on PyPI
+   :target: https://pypi.python.org/pypi/sentrylogs
+.. |build-status| image:: https://travis-ci.org/mdgart/sentrylogs.svg
+   :alt: Build status
+   :target: https://travis-ci.org/mdgart/sentrylogs
+.. |health| image:: https://landscape.io/github/mdgart/sentrylogs/master/landscape.svg?style=flat
+   :target: https://landscape.io/github/mdgart/sentrylogs/master
+   :alt: Code health
+.. |python-support| image:: https://img.shields.io/pypi/pyversions/sentrylogs.svg
+   :target: https://pypi.python.org/pypi/sentrylogs
+   :alt: Python versions
+.. |downloads| image:: https://img.shields.io/pypi/dm/sentrylogs.svg
+   :alt: Monthly downloads from PyPI
+   :target: https://pypi.python.org/pypi/sentrylogs
+.. |license| image:: https://img.shields.io/pypi/l/sentrylogs.svg
+   :alt: Software license
+   :target: https://github.com/mdgart/sentrylogs/blob/master/LICENSE.txt
 
 How it works
 ============


### PR DESCRIPTION
This PR adds sweet badges to the project repository README.

The empty FAQ.txt file (unused until now) is also removed.