### PR TITLE
Fix version history for v0.1.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,5 +7,5 @@ v0.0.6, 12/05/2012 -- Nginx default error log path fixed
 v0.0.7, 12/10/2012 -- Documentation bug fix
 v0.0.8, 01/16/2013 -- README.md addded to manifest
 v0.0.9, 02/18/2013 -- Patch for invalid Nginx errors
-v0.1.0, ??/??/???? -- (non-versioned release)
+v0.1.0, 07/25/2014 -- Fix syntax error in nginx parser (07/03/2013; released 1y later w/ non-versioned version bump)
 v0.1.1, 06/07/2016 -- Add static code analysis (flake8, pylint) and functional tests


### PR DESCRIPTION
As commented in [issue #6](https://github.com/mdgart/sentrylogs/issues/6#issuecomment-224573961).

* Code of 0.1.0 package on PyPI is identical with commit 3d3a8db (03-Jul-2013)
* Changes from version 0.0.9 to 0.1.0: https://github.com/mdgart/sentrylogs/compare/1a7a28b...3d3a8db

[Version 0.1.0](https://pypi.python.org/pypi/SentryLogs/0.1.0) was released on PyPI on 25-Jul-2014, a year after the changes had been made, on 03-Jul-2013. The version bump was obviously not put under version control back then.