### PR TITLE
Update interface for extended message for more recent versions of raven-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-raven>=2.0.10
+raven>=4
 tailer>=0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-raven>=4
+raven>=3.3.2
 tailer>=0.3

--- a/sentrylogs/helpers.py
+++ b/sentrylogs/helpers.py
@@ -4,16 +4,13 @@ Helper functions for Sentry Logs
 from .conf import client
 
 
-def send_message(message, extended_message, params, site, logger):
+def send_message(message, params, site, logger):
     """Send a message to the Sentry server"""
     client.capture(
         'Message',
         message=message,
+        params=type(params),message,
         data={
-            'sentry.interfaces.Message': {
-                'message': extended_message,
-                'params': tuple(params),
-            },
             'site': site,
             'logger': logger,
         },

--- a/sentrylogs/parsers/__init__.py
+++ b/sentrylogs/parsers/__init__.py
@@ -19,7 +19,6 @@ class Parser(object):
         self.filepath = filepath
         self.logger = self.__doc__.strip()
         self.message = None
-        self.extended_message = None
         self.params = None
         self.site = None
 
@@ -35,13 +34,11 @@ class Parser(object):
 
         for line in tailer.follow(logfile):
             self.message = None
-            self.extended_message = None
             self.params = None
             self.site = None
 
             self.parse(line)
             send_message(self.message,
-                         self.extended_message,
                          self.params,
                          self.site,
                          self.logger)
@@ -52,9 +49,8 @@ class Parser(object):
         The implementation must set these properties:
 
         - ``message`` (string)
-        - ``extended_message`` (string)
         - ``params`` (list of string)
         - ``site`` (string)
         """
         raise NotImplementedError('parse() method must set: '
-                                  'message, extended_message, params, site')
+                                  'message, params, site')

--- a/sentrylogs/parsers/nginx.py
+++ b/sentrylogs/parsers/nginx.py
@@ -40,16 +40,15 @@ class Nginx(Parser):
 
             otherinfo[key] = value
 
-        self.message = '%s' % date_time_message[2]
-        self.extended_message = '%s\n' \
-                                'Date: %s\n' \
-                                'Time: %s\n' \
-                                'Request: %s\n' \
-                                'Referrer: %s\n' \
-                                'Server: %s\n' \
-                                'Client: %s\n' \
-                                'Host: %s\n' \
-                                'Upstream: %s\n'
+        self.message = '%s\n' \
+                       'Date: %s\n' \
+                       'Time: %s\n' \
+                       'Request: %s\n' \
+                       'Referrer: %s\n' \
+                       'Server: %s\n' \
+                       'Client: %s\n' \
+                       'Host: %s\n' \
+                       'Upstream: %s\n'
         self.params = [
             date_time_message[2],
             date_time_message[0],


### PR DESCRIPTION
Thanks for this code! I noticed that the extended message was being ignored. The code seems to assume that the raven-python would handle the 'sentry.interfaces.Message' dict appropriately, but since at least raven-python 3.3.2 that key will be ignored by raven-python.
