### PR TITLE
type -> tuple typo

### DIFF
--- a/sentrylogs/helpers.py
+++ b/sentrylogs/helpers.py
@@ -9,7 +9,7 @@ def send_message(message, params, site, logger):
     client.capture(
         'Message',
         message=message,
-        params=type(params),
+        params=tuple(params),
         data={
             'site': site,
             'logger': logger,


### PR DESCRIPTION
Hi, this stupid typo snuck in. It prevents that params from being merged into the message.