### PR TITLE
use tailhead instead of tailer so as to handle rotating logs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 raven = ">=3.3.2"
-tailer = ">=0.3"
+tailhead = ">=1.0.2"
 
 [dev-packages]
 tox = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "de0df9a589fe9671861f30d4ef5844b32bb3b8ffc050554f500a3acab147e293"
+            "sha256": "c2b08001915bea459f949c285523b65b38969a9fc397a84aa2ed776e088326d2"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -16,52 +16,46 @@
     "default": {
         "raven": {
             "hashes": [
-                "sha256:3fd787d19ebb49919268f06f19310e8112d619ef364f7989246fc8753d469888",
                 "sha256:95f44f3ea2c1b176d5450df4becdb96c15bf2632888f9ab193e9dd22300ce46a"
             ],
             "index": "pypi",
             "version": "==6.9.0"
         },
-        "tailer": {
+        "tailhead": {
             "hashes": [
-                "sha256:78d60f23a1b8a2d32f400b3c8c06b01142ac7841b75d8a1efcb33515877ba531"
+                "sha256:916f70583494f38009410f178c3aea3f3b5e3f3b9c2d83f643547b2651147a03"
             ],
             "index": "pypi",
-            "version": "==0.4.1"
+            "version": "==1.0.2"
         }
     },
     "develop": {
         "filelock": {
             "hashes": [
-                "sha256:b8d5ca5ca1c815e1574aee746650ea7301de63d87935b3463d26368b76e31633",
-                "sha256:d610c1bb404daf85976d7a82eb2ada120f04671007266b708606565dd03b5be6"
+                "sha256:b8d5ca5ca1c815e1574aee746650ea7301de63d87935b3463d26368b76e31633"
             ],
             "version": "==3.0.10"
         },
         "pluggy": {
             "hashes": [
-                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
                 "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
             ],
             "version": "==0.8.0"
         },
         "py": {
             "hashes": [
-                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
                 "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
             ],
             "version": "==1.7.0"
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
                 "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
         },
         "toml": {
             "hashes": [
-                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
             "version": "==0.10.0"
@@ -76,8 +70,7 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:686176c23a538ecc56d27ed9d5217abd34644823d6391cbeb232f42bf722baad",
-                "sha256:f899fafcd92e1150f40c8215328be38ff24b519cd95357fa6e78e006c7638208"
+                "sha256:686176c23a538ecc56d27ed9d5217abd34644823d6391cbeb232f42bf722baad"
             ],
             "version": "==16.1.0"
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 raven>=3.3.2
-tailhead
+tailhead>=1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 raven>=3.3.2
-https://github.com/six8/pytailer/zipball/c9e8a1fc52e148ca165df4982164aba249b60ba1
+tailhead

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 raven>=3.3.2
-tailer>=0.3
+https://github.com/six8/pytailer/zipball/c9e8a1fc52e148ca165df4982164aba249b60ba1

--- a/sentrylogs/parsers/__init__.py
+++ b/sentrylogs/parsers/__init__.py
@@ -1,7 +1,7 @@
 """
 Log file parsers provided by Sentry Logs
 """
-import tailer  # same functionality as UNIX tail in python
+import tailhead  # same functionality as UNIX tail in python
 
 from ..helpers import send_message
 
@@ -27,13 +27,14 @@ class Parser:
         Read (tail and follow) the log file, parse entries and send messages
         to Sentry using Raven.
         """
+
         try:
-            logfile = open(self.filepath)
+            follower = tailhead.follow_path(self.filepath)
         except (FileNotFoundError, PermissionError) as err:
             raise SystemExit("Error: Can't read logfile %s (%s)" %
                              (self.filepath, err))
 
-        for line in tailer.follow(logfile):
+        for line in follower:
             self.message = None
             self.params = None
             self.site = None

--- a/sentrylogs/parsers/__init__.py
+++ b/sentrylogs/parsers/__init__.py
@@ -39,11 +39,12 @@ class Parser:
             self.params = None
             self.site = None
 
-            self.parse(line)
-            send_message(self.message,
-                         self.params,
-                         self.site,
-                         self.logger)
+            if line is not None:
+                self.parse(line)
+                send_message(self.message,
+                             self.params,
+                             self.site,
+                             self.logger)
 
     def parse(self, line):
         """


### PR DESCRIPTION
The current version of tailer does not follow the name of a file, it follows a file descriptor. This means that if you rotate the log files, sentrylogs will not see any of the new information in the new file. 

<s>This PR https://github.com/six8/pytailer/pull/12 adds code into the tailer's follow method to change the behavior to follow a filename. </s>

This PR swaps out the tailing dependency from `tailer` to `tailhead` in order to take advantage of `tailhead` ability to follow a filename.

