### PR TITLE
Send Sentry report when error log does not match regex

### DIFF
--- a/sentrylogs/parsers/nginx.py
+++ b/sentrylogs/parsers/nginx.py
@@ -49,6 +49,10 @@ class Nginx(Parser):
         csv_list = line.split(",")
 
         regex = re.match(self.pattern, csv_list.pop(0))
+        if not regex:
+            self.level = "fatal"
+            self.message = line
+            return
         self.data["date"] = regex.group("date")
         self.data["time"] = regex.group("time")
         self.level = self.get_sentry_log_level(regex.group("level"))

--- a/tests/test_nginx.py
+++ b/tests/test_nginx.py
@@ -56,3 +56,22 @@ def test_regex():
         n.clear_attributes()
         n.parse(log)
         assert message == n.message
+
+
+def test_error_does_not_match_regex():
+    """
+    Test when the regex does not match
+    """
+    logs = (
+        'nginx: [emerg] open() "/etc/nginx/mime.types" failed (2: No such file or directory) in /opt/bitnami/nginx/conf/server_blocks/server-block.conf:24',  # noqa: E501
+    )
+
+    level = "fatal"
+
+    n = Nginx()
+    for log in logs:
+        message = log
+        n.clear_attributes()
+        n.parse(log)
+        assert level == n.level
+        assert message == n.message


### PR DESCRIPTION
Today I had a log that didn't match the regex.

There was still a Sentry error because `regex` was `None` for `regex.group("date")`.

```
AttributeError: 'NoneType' object has no attribute 'group'
  File "sentrylogs", line 11, in <module>
    sys.exit(main())
  File "sentrylogs/bin/sentrylogs.py", line 111, in main
    launch_log_parsers()
  File "sentrylogs/bin/sentrylogs.py", line 103, in launch_log_parsers
    parser().follow_tail()
  File "sentrylogs/parsers/__init__.py", line 53, in follow_tail
    self.parse(line)
  File "sentrylogs/parsers/nginx.py", line 52, in parse
    self.data["date"] = regex.group("date")
```