### PR TITLE
Test against Python 3.8, PyPy and PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 dist: xenial
 sudo: true
-language: python
 
+language: python
 python:
 - 2.7
 - 3.4
 - 3.5
 - 3.6
 - 3.7
+- 3.8
+- pypy2.7-6.0
+- pypy3.5
 
 install:
 - pip install tox-travis
@@ -20,5 +23,7 @@ stages:
 
 jobs:
   include:
+  - { stage: lint, python: 3.7, env: TOXENV=bandit }
   - { stage: lint, python: 3.7, env: TOXENV=flake8 }
   - { stage: lint, python: 3.7, env: TOXENV=pylint }
+  - { stage: lint, python: 3.7, env: TOXENV=readme }

--- a/README.rst
+++ b/README.rst
@@ -101,10 +101,17 @@ How to Contribute
 Please `open an issue`_ to discuss your plans for a `pull request`_.  After
 writing code make sure your changes pass our quality gate before you push.
 
-.. code-block:: bash
+.. code-block:: console
 
-    $ tox
-    $ python setup.py clean
+    # list all tox targets
+    tox -lv
+
+    # run all linting and tests
+    tox
+
+    # run tests just for Python 3.8
+    # (e.g. if you don't have all Pythons installed via pyenv)
+    tox -e py38
 
 Please write tests!  Test coverage is still low and the code quality needs
 to improve.  Please help by adding tests with each contribution you make!

--- a/setup.py
+++ b/setup.py
@@ -1,69 +1,11 @@
 #!/usr/bin/env python3
-"""Packaging implementation for Sentry Logs"""
-from __future__ import print_function
-
-from glob import glob
-import os
+"""
+Packaging setup for Sentry Logs
+"""
 from os.path import abspath, dirname, join
-import shutil
-
-from setuptools import Command, setup
+from setuptools import setup
 
 import sentrylogs as package
-
-
-class SimpleCommand(Command):
-    """A simple setuptools command (implementation of abstract base class)"""
-    user_options = []
-
-    def initialize_options(self):
-        """Abstract method of the base class (required to be overridden)"""
-
-    def finalize_options(self):
-        """Abstract method of the base class (required to be overridden)"""
-
-
-class Clean(SimpleCommand):
-    """Remove build files and folders, including Python byte-code"""
-    description = __doc__
-
-    @staticmethod
-    def run():
-        """
-        Clean up files not meant for version control
-        """
-        delete_in_root = [
-            'build',
-            'dist',
-            '.eggs',
-            '*.egg-info',
-            '.tox',
-        ]
-        delete_everywhere = [
-            '*.pyc',
-            '__pycache__',
-        ]
-        for candidate in delete_in_root:
-            rmtree_glob(candidate)
-        for visible_dir in glob('[A-Za-z0-9_]*'):
-            for candidate in delete_everywhere:
-                rmtree_glob(join(visible_dir, candidate))
-                rmtree_glob(join(visible_dir, '*', candidate))
-                rmtree_glob(join(visible_dir, '*', '*', candidate))
-
-
-def rmtree_glob(file_glob):
-    """Platform independent rmtree, which also allows wildcards (globbing)"""
-    for item in glob(file_glob, recursive=True):
-        try:
-            os.remove(item)
-            print('%s removed ...' % item)
-        except OSError:
-            try:
-                shutil.rmtree(item)
-                print('%s/ removed ...' % item)
-            except OSError as err:
-                print(err)
 
 
 def read_file(filename):
@@ -89,9 +31,13 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
     description=package.__doc__.strip(),
     long_description=read_file('README.rst'),
+    long_description_content_type='text/x-rst',
     license=package.__license__,
     url=package.__url__,
     install_requires=read_file('requirements.txt'),
@@ -108,7 +54,4 @@ setup(
     ],
     test_suite='tests',
     tests_require=['tox'],
-    cmdclass={
-        'clean': Clean,
-    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,55 @@
 [tox]
 envlist =
+    bandit
     flake8
     pylint
-    python
+    py{27,34,35,36,37,38,py,py3}
+    readme
+    clean
 
 [testenv]
+description = Unit tests
 deps =
     cli-test-helpers
     py27: mock
+    pypy: mock
     pytest
 commands = pytest
 usedevelop = True
 
+[testenv:bandit]
+description = PyCQA security linter
+deps = bandit<1.6.0
+commands = bandit -r . --ini tox.ini
+
+[testenv:clean]
+description = Clean up bytecode and other debris
+deps = pyclean
+commands =
+    py3clean -v {toxinidir}
+    rm -rf build/ dist/ SentryLogs.egg-info/ .pytest_cache/ .tox/
+whitelist_externals =
+    rm
+
 [testenv:flake8]
+description = Static code analysis and code style
 deps = flake8
 commands = flake8
 
 [testenv:pylint]
+description = Check for errors and code smells
 deps = pylint
 commands = pylint --rcfile=tox.ini setup.py sentrylogs
+
+[testenv:readme]
+description = Ensure README renders on PyPI
+deps = twine
+commands =
+    {envpython} setup.py -q sdist bdist_wheel
+    twine check dist/*
+
+[bandit]
+exclude = .tox,build,dist,tests
 
 [flake8]
 max-line-length = 81


### PR DESCRIPTION
* Test against Python 3.8, PyPy and PyPy3
* Test explicit Python versions with Tox
* Add more Tox targets (bandit, clean, readme)
* Also removes the cleanup logic from `setup.py` 